### PR TITLE
Add wrapper for oss index connectivity errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,17 @@
+OSSINDEX_ERRORS = "Unable to contact OSS Index|authentication failed|401 Unauthorized|403 Forbidden|429 Too Many Requests|Too many requests|Rate limit|Unknown host|Connection refused|timed out|unreachable|402 Payment Required"
+
 .PHONY: all
 all: audit test build lint
 
 .PHONY: audit
 audit:
-	mvn ossindex:audit
+	@echo "🔍 Running OSS Index audit for httpino"
+	@mkdir -p target
+	@mvn ossindex:audit > target/ossindex-audit-httpino.log 2>&1; status=$$?; \
+	cat target/ossindex-audit-httpino.log; \
+	[ $$status -eq 0 ] && grep -Eiqn $(OSSINDEX_ERRORS) target/ossindex-audit-httpino.log && \
+		{ echo "❌ OSS Index API/auth/network error (CMS) — see target/ossindex-audit-httpino.log"; exit 1; }; \
+	exit $$status
 
 .PHONY: build
 build:

--- a/ci/scripts/audit.sh
+++ b/ci/scripts/audit.sh
@@ -1,5 +1,34 @@
 #!/bin/bash -eux
 
+# Ensure required environment variables are set
+if [[ -z "${OSSINDEX_USERNAME:-}" || -z "${OSSINDEX_TOKEN:-}" ]]; then
+  echo "Error: OSSINDEX_USERNAME and OSSINDEX_TOKEN must be set" >&2
+  exit 1
+fi
+
+# Stop if settings already exist to avoid overwriting
+if [[ -f ~/.m2/settings.xml ]]; then
+  echo "Maven settings file already exists - not overwriting." >&2
+  exit 1
+fi
+
+# Create Maven settings directory and file
+mkdir -p ~/.m2
+cat > ~/.m2/settings.xml << EOF
+<settings>
+  <servers>
+    <server>
+      <id>ossindex</id>
+      <username>${OSSINDEX_USERNAME}</username>
+      <password>${OSSINDEX_TOKEN}</password>
+    </server>
+  </servers>
+</settings>
+EOF
+
+# Secure the file
+chmod 600 ~/.m2/settings.xml
+
 pushd httpino
     make audit
 popd

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,7 @@
                 </executions>
                 <!-- configuration for mvn ossindex:audit -->
                 <configuration>
+                    <authId>ossindex</authId>
                     <!-- if CVSS >= 7.0 (high or critical) then ERROR else WARN -->
                     <fail>true</fail>
                     <cvssScoreThreshold>7.0</cvssScoreThreshold>


### PR DESCRIPTION
### What

Adding a wrapper around ossindex failures - this should ensure that connectivity failures don't fail silently.

### How to review

Check looks ok - will fail at the moment.

### Who can review

Not me.
